### PR TITLE
29 VariableDistance refsize and DimensionMismatch checks

### DIFF
--- a/src/SoleData.jl
+++ b/src/SoleData.jl
@@ -133,7 +133,7 @@ export VarFeature,
         VariableMin, VariableMax, i_variable, featurename,
         VariableSoftMin, VariableSoftMax,
         VariableAvg,
-        VariableDistance, references, distance,
+        VariableDistance, references, refsize, distance,
         MultivariateFeature
 
 

--- a/src/dimensional-structures/computefeature.jl
+++ b/src/dimensional-structures/computefeature.jl
@@ -43,6 +43,9 @@ function computeunivariatefeature(f::VariableAvg, varchannel::AbstractArray{T}) 
     (mean(varchannel))
 end
 function computeunivariatefeature(f::VariableDistance, varchannel::AbstractArray{T}) where {T}
+    size(varchannel) == refsize(f) || throw(DimensionMismatch(
+        "Trying to compare size $(size(varchannel)) with $(refsize(f))"))
+
     (map(reference -> distance(f)(varchannel,reference), references(f)) |> minimum)
 end
 
@@ -61,7 +64,4 @@ function computeunivariatefeature(f::VariableSoftMax, varchannel::T) where {T}
 end
 function computeunivariatefeature(f::VariableAvg, varchannel::T) where {T}
     varchannel
-end
-function computeunivariatefeature(f::VariableDistance, varchannel::T) where {T}
-    (map(reference -> distance(f)(varchannel,reference), references(f)) |> minimum)
 end

--- a/src/scalar/var-features.jl
+++ b/src/scalar/var-features.jl
@@ -492,19 +492,21 @@ By default, `distance` is set to be Euclidean distance and the lowest result is 
 
 # Examples
 ```julia
-# we only want to perform comparisons with one important representative signal (a reference)
-julia> vd = VariableDistance(1, [1,2,3,4]; featurename="StrictMonotonicAscending");
+# we only want to perform comparisons with one important representative signal;
+# we call such signal a reference, and encapsulate it within an array.
+julia> vd = VariableDistance(1, [[1,2,3,4]]; featurename="StrictMonotonicAscending");
 
 julia> syntaxstring(vd)
 "StrictMonotonicAscending[V1]"
 
+# compute the distance (euclidean by default) with the given signal
 julia> computeunivariatefeature(vd, [1,2,3,4])
 0.0
 
 julia> computeunivariatefeature(vd, [2,3,4,5])
 2.0
 
-# we consider multiple references
+# now we consider multiple references
 julia> vd = VariableDistance(1, [
         [0.1,1.8,3.0,3.2],
         [1.1,1.3,2.3,3.8],
@@ -516,6 +518,11 @@ julia> vd = VariableDistance(1, [
 # return only the minimum distance w.r.t. all the references wrapped within vd
 julia> computeunivariatefeature(vd, [1,2,3,4])
 0.812403840463596
+
+# we ask for the size of a generic reference
+julia> refsize(vd)
+(4,)
+
 ```
 
 See also [`SoleLogics.Interval`](@ref),
@@ -547,7 +554,7 @@ end
 featurename(f::VariableDistance) = string(f.featurename)
 
 references(f::VariableDistance) = f.references
-refsize(f::VariableDistance) = references(f) |> size
+refsize(f::VariableDistance) = references(f) |> first |> size
 distance(f::VariableDistance) = f.distance
 
 function featvaltype(dataset, f::VariableDistance)

--- a/src/scalar/var-features.jl
+++ b/src/scalar/var-features.jl
@@ -526,23 +526,28 @@ See also [`SoleLogics.Interval`](@ref),
 """
 struct VariableDistance{I<:VariableId,T} <: AbstractUnivariateFeature
     i_variable::I
-    references::Vector{<:T}
+    references::AbstractArray{T}
     distance::Function
     featurename::VariableName
 
     function VariableDistance(
         i_variable::I,
-        references::Vector{<:T};
+        references::AbstractArray{T};
         # euclidean distance, but with no Distances.jl dependency
         distance::Function=(x,y) -> sqrt(sum([(x - y)^2 for (x, y) in zip(x,y)])),
         featurename = "Δ"
     ) where {I<:VariableId,T}
+        if any(r -> size(r) != size(references |> first), references)
+            throw(DimensionMismatch("References' sizes are not unique."))
+        end
+
         return new{I,T}(i_variable, references, distance, featurename)
     end
 end
 featurename(f::VariableDistance) = string(f.featurename)
 
 references(f::VariableDistance) = f.references
+refsize(f::VariableDistance) = references(f) |> size
 distance(f::VariableDistance) = f.distance
 
 function featvaltype(dataset, f::VariableDistance)

--- a/test/var-features.jl
+++ b/test/var-features.jl
@@ -15,8 +15,12 @@ vd = VariableDistance(1, sequence) # id=1 is totally arbitrary
 @test computeunivariatefeature(vd, references(vd)) == 0.0
 @test_throws DimensionMismatch computeunivariatefeature(vd, too_long_sequence) == 0.4
 
-propositional_vd = VariableDistance(1, 36)
-@test computeunivariatefeature(propositional_vd, 37) == 1.0
+# in the degenerate case in which we wrap a single value inside a VariableDistance,
+# we do not want to consider it as a simple scalar, but as a signal containing only
+# one record.
+propositional_vd = VariableDistance(1, [[36]])
+@test_throws MethodError propositional_vd = VariableDistance(1, 36)
+@test computeunivariatefeature(propositional_vd, [37]) == 1.0
 
 vnamed = VariableValue(1, "feature_name")
 @test i_variable(vnamed) == 1
@@ -40,6 +44,7 @@ unf2 = UnivariateNamedFeature(var_id, var_name)
 
 
 # case in which a VariableDistance wraps multiple references
+@test_throws DimensionMismatch vd = VariableDistance(1, [sequences, too_long_sequence])
 vd = VariableDistance(1, sequences)
 @test references(vd) |> length == 3
 @test computeunivariatefeature(vd, sequence) == 0

--- a/test/var-features.jl
+++ b/test/var-features.jl
@@ -12,7 +12,7 @@ vd = VariableDistance(1, sequence) # id=1 is totally arbitrary
 @test i_variable(vd) == 1
 @test references(vd) == sequence
 
-@test computeunivariatefeature(vd, references(vd)) == 0
+@test computeunivariatefeature(vd, references(vd)) == 0.0
 @test_throws DimensionMismatch computeunivariatefeature(vd, too_long_sequence) == 0.4
 
 propositional_vd = VariableDistance(1, 36)


### PR DESCRIPTION
v = VariableDistance is now extended with a refisze method, which returns the size of any element in references(v).
Note that this differs from saying v |> references |> size.

Also, now it is assured that all the wrapped references have the same size.