### PR TITLE
New readfeature dispatch for VariableDistance 

### DIFF
--- a/src/dimensional-structures/computefeature.jl
+++ b/src/dimensional-structures/computefeature.jl
@@ -42,7 +42,10 @@ end
 function computeunivariatefeature(f::VariableAvg, varchannel::AbstractArray{T}) where {T}
     (mean(varchannel))
 end
-function computeunivariatefeature(f::VariableDistance, varchannel::AbstractArray{T}) where {T}
+function computeunivariatefeature(
+    f::VariableDistance,
+    varchannel::AbstractArray{T}
+) where {T}
     size(varchannel) == refsize(f) || throw(DimensionMismatch(
         "Trying to compare size $(size(varchannel)) with $(refsize(f))"))
 

--- a/src/scalar/scalarlogiset.jl
+++ b/src/scalar/scalarlogiset.jl
@@ -403,7 +403,7 @@ function naturalconditions(
         return (test_ops,cond)
     end
     univar_condition(i_var,::Any) = throw_n_log("Unknown mixed_feature type: $(cond), $(typeof(cond))")
-    
+
     # readymade conditions
     unpackcondition(cond::ScalarMetaCondition) = [cond]
     unpackcondition(feature::AbstractFeature) = [ScalarMetaCondition(feature, test_op) for test_op in def_test_operators]
@@ -417,7 +417,7 @@ function naturalconditions(
         [(test_ops, cond)]
     end
     unpackcondition(cond::Tuple{TestOperator,PatchedFunction}) = unpackcondition(cond[2], [cond[1]])
-    
+
     function unpackcondition(cond::Base.Callable, test_ops = def_test_operators)
         if fixcallablenans
             [([test_operator], nanpatchedfunction(cond,test_operator)) for test_operator in test_ops]


### PR DESCRIPTION
When creating a `scalarlogiset`, `readfeature` is called to evaluate a feature on each world of a model.

With the new dispatch, the feature encoded by a VariableDistance can fail when evaluated on models with a different size w.r.t. the references within the VariableDistance. 

The failure is inevitable, since we are only interested in specific worlds rather than all the N*(N-1)/2 worlds (in the case of an intervallar model). 

The solution is simple: Inf is returned when failure happens.