### PR TITLE
skipped 0.16.2 version number

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SoleData"
 uuid = "123f1ae1-6307-4526-ab5b-aab3a92a2b8c"
 authors = ["Mauro MILELLA", "Giovanni PAGLIARINI", "Edoardo PONSANESI", "Riccardo PASINI"]
-version = "0.16.3"
+version = "0.16.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"


### PR DESCRIPTION
SoleData version 0.16.2 actually wasn't released.
To keep consistency it's better to downgrade this release to version 0.16.2 before release it.