### PR TITLE
[FIX] Correct sha256 in Artifacts.toml

### DIFF
--- a/src/artifacts/Artifacts.toml
+++ b/src/artifacts/Artifacts.toml
@@ -2,40 +2,40 @@
 git-tree-sha1 = "2fde6d24ce7bffccc0a66a5447787bd95a057cca"
 
     [[abc.download]]
-    sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    sha256 = "a52485c26d1c239f97921a1b726faad5f0e642470a592234bdca2334c9892b7c"
     url = "https://github.com/aclai-lab/Artifacts/raw/main/sole/binaries/generic/abc.tar.gz"
 
 [libras]
 git-tree-sha1 = "5c13bb56bcf0d6866d26c80fde16b27e6ad2e75f"
 
     [[libras.download]]
-    sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    sha256 = "f67eda8a327217b18c9c22a19abc6f8a60e188107b0474c7836951edab41e407"
     url = "https://github.com/aclai-lab/Artifacts/raw/main/sole/datasets/libras.tar.gz"
 
 [natops]
 git-tree-sha1 = "3838ff4af3c2cf45a1cb6369a6138329f6362dcc"
 
     [[natops.download]]
-    sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    sha256 = "73e17a9f699a8222ffe4307c7d56674f71e5fd232ab75a855fd4e4901bc63bf5"
     url = "https://github.com/aclai-lab/Artifacts/raw/main/sole/datasets/natops.tar.gz"
 
 [mitespresso]
 git-tree-sha1 = "dbe79220f8352a25e5a79cdc3ede3c58abf9038f"
 
     [[mitespresso.download]]
-    sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    sha256 = "1b7655f5dc98f8484a6ec1fa709e03af16536cc98fc82a09eab1cb325d8234d5"
     url = "https://github.com/aclai-lab/Artifacts/raw/main/sole/binaries/minimizers/mitespresso.tar.gz"
 
 [epilepsy]
 git-tree-sha1 = "d4a858762ece9feb48b15831b93069f638ac610a"
 
     [[epilepsy.download]]
-    sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    sha256 = "d40fb45e1f1ecb696036c57602a87aa45a0f42e2e35baaccc8e4a1f301f74dbe"
     url = "https://github.com/aclai-lab/Artifacts/raw/main/sole/datasets/epilepsy.tar.gz"
 
 [hugadb]
 git-tree-sha1 = "a59cc61429942aa77b0d6a0bc2ffcf6f47acf7e0"
 
     [[hugadb.download]]
-    sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    sha256 = "e34ccf94cb1830cfda0c3007fbdb8a8810bcdde3e0219a12815fecff61798541"
     url = "https://github.com/aclai-lab/Artifacts/raw/main/sole/datasets/hugadb.tar.gz"

--- a/src/artifacts/utils/artifact-utils.jl
+++ b/src/artifacts/utils/artifact-utils.jl
@@ -76,7 +76,7 @@ function fillartifacts(url::String)
             # to do so, we could iterate some kwargs here.
             new_entry = Dict{String,Any}()
             content[filename_no_extension]["download"] = [new_entry]
-            new_entry["sha256"] = bytes2hex(open(sha256, artifact_path(SHA1)))
+            new_entry["sha256"] = file_sha256
             new_entry["url"] = url
         end
 


### PR DESCRIPTION
This pull request aims to fix the error in the creation of the `Artifacts.toml` file, where the sha256 hashes were incorrect, leading to errors when downloading datasets via SoleData, as the calculated hash did not match the expected one.

The sha256 hashes in the `Artifacts.toml` file were all identical and incorrect. This issue occurred because the `fillartifacts` function in `artifact-utils.jl` did not properly use the sha256 hash of the downloaded file.

A correct version of this function exists in `src/loaders` under the name `fill_artifacts`. However, this function is not exported, while the incorrect one is.