### PR TITLE
float type selection for minimizations

### DIFF
--- a/src/minimize.jl
+++ b/src/minimize.jl
@@ -550,7 +550,8 @@ function espresso_minimize(
     atoms::Vector{Vector{Atom}},
     binary::String;
     allow_scalar_range_conditions::Bool=false,
-    depth::Float64=1.0
+    depth::Float64=1.0,
+    float_type::Type=Float64
     # syntaxtree::SoleLogics.Formula,
     # silent::Bool=true,
 
@@ -621,7 +622,8 @@ function abc_minimize(
     binary::String;
     fast::Int64=1,
     allow_scalar_range_conditions::Bool=false,
-    depth::Float64=1.0
+    depth::Real=1.0,
+    float_type::Type=Float64
 )
     # convert formula to pla string format
     pla_string, fnames = PLA.formula_to_pla(
@@ -665,7 +667,7 @@ function abc_minimize(
             SoleData.RangeScalarCondition :
             SoleData.ScalarCondition
 
-        return PLA.pla_to_formula(minimized_pla, fnames; conditionstype)
+        return PLA.pla_to_formula(minimized_pla, fnames; conditionstype, float_type)
     end
 end
 

--- a/src/scalar-pla.jl
+++ b/src/scalar-pla.jl
@@ -56,7 +56,7 @@ end
         conditions::Vector{<:SoleData.ScalarCondition},
         includes::Vector{BitMatrix},
         excludes::Vector{BitMatrix},
-        feat_condindxss::Vector{Vector{Int64}}
+        feat_condindxss::Vector{Vector{Int}}
     ) -> Vector{String}
 
     Encode a logical disjunct into a Programmable Logic Array (PLA) row representation.
@@ -71,7 +71,7 @@ end
     - `conditions::Vector{<:SoleData.ScalarCondition}`: Vector of all possible conditions 
     - `includes::Vector{BitMatrix}`: Matrix-like structure defining inclusion relationships between conditions
     - `excludes::Vector{BitMatrix}`: Matrix-like structure defining exclusion relationships between conditions
-    - `feat_condindxss::Vector{Vector{Int64}}`: Mapping from features to their corresponding condition indices
+    - `feat_condindxss::Vector{Vector{Int}}`: Mapping from features to their corresponding condition indices
 
     # Returns
     - `Vector{String}`: PLA row representation where each element is "1", "0", or "-"
@@ -93,7 +93,7 @@ function _encode_disjunct(
     conditions::Vector{<:SD.AbstractScalarCondition},
     includes::Vector{BitMatrix},
     excludes::Vector{BitMatrix},
-    feat_condindxss::Vector{Vector{Int64}},
+    feat_condindxss::Vector{Vector{Int}},
 )
     pla_row = fill("-", length(conditions))
 
@@ -196,10 +196,12 @@ The function:
 - The feature name must exist in `fnames` to determine the variable index
 """
 function _read_conditions(
-    line::AbstractString, conditionstype::Type, fnames::Vector{<:VariableValue}; float_type::Type=Float64
+    line::AbstractString,
+    conditionstype::Type,
+    fnames::Vector{<:VariableValue};
+    float_type::Type=Float64
 )
     parts = split(line, ' ')[2:end]  # skip '.ilb' command
-    fnames = Symbol.(featurename.(fnames))
 
     return map(parts) do part
         # split with regex
@@ -208,7 +210,11 @@ function _read_conditions(
 
         # reconstruct VariableValue
         varname = Symbol(m.captures[1])
-        i_var = findfirst(==(varname), fnames)
+
+        i_fname = findfirst(f -> Symbol(featurename(f)) == varname, fnames)
+        i_fname === nothing && throw(ArgumentError("Unknown feature name: $(varname)"))
+        i_var = fnames[i_fname].i_variable
+
         value = SD.VariableValue(i_var, varname)
 
         operator = OPERATOR_MAP[m.captures[2]]
@@ -238,7 +244,7 @@ _onset_rows(row::Vector{String}) = "$(join(row, "")) 1" # Append "1" for the ON-
 # ---------------------------------------------------------------------------- #
 #                              multivariate utils                              #
 # ---------------------------------------------------------------------------- #
-function _header(feat_nconds::Vector{Int64}, feat_condnames::Vector{Vector{String}})
+function _header(feat_nconds::Vector{Int}, feat_condnames::Vector{Vector{String}})
     num_binary_vars = sum(feat_nconds .== 1)
     num_nonbinary_vars = sum(feat_nconds .> 1) + 1
     num_vars = num_binary_vars + num_nonbinary_vars
@@ -263,7 +269,7 @@ function _header(feat_nconds::Vector{Int64}, feat_condnames::Vector{Vector{Strin
     return pla_header
 end
 
-function _onset_rows(feat_nconds::Vector{Int64}, row::Vector{String})
+function _onset_rows(feat_nconds::Vector{Int}, row::Vector{String})
     num_binary_vars = sum(feat_nconds .== 1)
 
     # generate on-set rows for each disjunct    
@@ -427,7 +433,7 @@ function formula_to_pla(
     conditions = SD.removeduals(conditions)
 
     # for each feature, derive the conditions, and their names
-    feat_condindxss = Vector{Vector{Int64}}(undef, nfnames)
+    feat_condindxss = Vector{Vector{Int}}(undef, nfnames)
     feat_condnames = Vector{Vector{String}}(undef, nfnames)
 
     @inbounds for (i, feat) in enumerate(fnames)

--- a/src/scalar-pla.jl
+++ b/src/scalar-pla.jl
@@ -38,7 +38,12 @@ const LiteralBool = Dict('1' => true, '0' => false)
 #                                 print utils                                  #
 # ---------------------------------------------------------------------------- #
 function _featurename(f::SD.VariableValue)
-    isnothing(f.i_name) ? "V$(f.i_variable)" : "[$(f.i_name)]"
+    return if isnothing(f.i_name)
+        f.i_variable isa Union{Symbol,AbstractString} ?
+            "$(f.i_variable)" : "V$(f.i_variable)"
+    else
+        "$(f.i_name)"
+    end
 end
 
 # ---------------------------------------------------------------------------- #
@@ -153,7 +158,8 @@ end
     _read_conditions(
         line::AbstractString,
         conditionstype::Type,
-        fnames::Vector
+        fnames::Vector;
+        float_type::Type=Float64
     ) -> Vector{SoleLogics.Atom}
 
 Parse a PLA input label line (`.ilb`) and extract scalar conditions as atoms.
@@ -190,7 +196,7 @@ The function:
 - The feature name must exist in `fnames` to determine the variable index
 """
 function _read_conditions(
-    line::AbstractString, conditionstype::Type, fnames::Vector{<:VariableValue}
+    line::AbstractString, conditionstype::Type, fnames::Vector{<:VariableValue}; float_type::Type=Float64
 )
     parts = split(line, ' ')[2:end]  # skip '.ilb' command
     fnames = Symbol.(featurename.(fnames))
@@ -206,7 +212,7 @@ function _read_conditions(
         value = SD.VariableValue(i_var, varname)
 
         operator = OPERATOR_MAP[m.captures[2]]
-        threshold = threshold = parse(Float64, m.captures[3])
+        threshold = threshold = parse(float_type, m.captures[3])
 
         condition = conditionstype(value, operator, threshold)
 
@@ -489,7 +495,8 @@ end
         pla::String,
         fnames::Vector{<:VariableValue};
         conditionstype::Type=SoleData.ScalarCondition,
-        conjunct::Bool=false
+        conjunct::Bool=false,
+        float_type::Type=Float64
     ) -> Union{SoleLogics.Formula, Vector{SyntaxStructure}}
 
 Convert a Programmable Logic Array (PLA) format string back into a logical formula representation.
@@ -592,6 +599,7 @@ function pla_to_formula(
     fnames::Vector{<:VariableValue};
     conditionstype::Type=SD.ScalarCondition,
     conjunct::Bool=false,
+    float_type::Type=Float64
 )
     lines = split(pla, '\n')
     parsed_conditions = SoleLogics.Atom[]
@@ -599,7 +607,7 @@ function pla_to_formula(
 
     for line in lines
         startswith(line, ".ilb") &&
-            append!(parsed_conditions, _read_conditions(line, conditionstype, fnames))
+            append!(parsed_conditions, _read_conditions(line, conditionstype, fnames; float_type))
         startswith(line, ['0', '1', '-', '|']) && append!(binaries, [line[1:(end - 2)]])
     end
 
@@ -617,7 +625,7 @@ function pla_to_formula(
             allow_scalar_range_conditions=false
         )
     end
-
+    
     return conjunct ? LeftmostDisjunctiveForm(disjuncts) : disjuncts
 end
 

--- a/src/scalar/var-features.jl
+++ b/src/scalar/var-features.jl
@@ -313,7 +313,14 @@ struct VariableValue{I<:VariableId,N<:Union{VariableName,Nothing}} <:
         return new{I,N}(i_variable, i_name)
     end
 end
-featurename(f::VariableValue) = !isnothing(f.i_name) ? f.i_name : "V$(f.i_variable)"
+function featurename(f::VariableValue)
+    return if isnothing(f.i_name)
+        f.i_variable isa Union{Symbol,AbstractString} ?
+            "$(f.i_variable)" : "V$(f.i_variable)"
+    else
+        f.i_name
+    end
+end
 
 function syntaxstring(
     f::VariableValue; variable_names_map=nothing, show_colon=false, kwargs...

--- a/src/utils/autologiset-tools.jl
+++ b/src/utils/autologiset-tools.jl
@@ -288,7 +288,7 @@ function autologiset(
         if X isa AbstractDataFrame
             allowedcoltypes = Union{
                 Real,
-                AbstractArray{<:Real,0},
+                AbstractArray{<:Real},
                 AbstractVector{<:Real},
                 AbstractMatrix{<:Real},
             }


### PR DESCRIPTION
We have tested that having the possibility to choose float format (Float32 or Float64) can improve in same cases, memory usage and overall performances for abc and mit espresso minimizations algorithm